### PR TITLE
fix(Tracking): worklog start time is saved as if it had started when we hit the stop button.

### DIFF
--- a/app/components/TextField/TextField.jsx
+++ b/app/components/TextField/TextField.jsx
@@ -6,6 +6,8 @@ import { FieldBaseStateless } from '@atlaskit/field-base';
 export default class extends PureComponent {
   static defaultProps = {
     onChange: () => {},
+    onFocus: () => {},
+    onBlur: () => {},
   }
 
   state = {

--- a/app/sagas/worklogs.js
+++ b/app/sagas/worklogs.js
@@ -64,7 +64,12 @@ export function* uploadWorklog(options: UploadWorklogOptions): Generator<*, *, *
       keepedIdles,
     }:
     UploadWorklogOptions = options;
-    const started = moment().utc().format().replace('Z', '.000+0000');
+    const started = moment()
+      .subtract({ seconds: timeSpentSeconds })
+      .utc()
+      .format()
+      .replace('Z', '.000+0000');
+
     // if timeSpentSeconds is less than a minute JIRA wont upload it so cancel
     if (timeSpentSeconds < 60) {
       yield call(


### PR DESCRIPTION
ISSUES CLOSED: #35
