### PR TITLE
Add a "Now Button", set time and date to now on manual worklog,

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ main.js.map
 npm-debug.log.*
 worklogs/*
 screenshots/*
+
+package-lock\.json

--- a/app/containers/Modals/WorklogModal/WorklogModal.jsx
+++ b/app/containers/Modals/WorklogModal/WorklogModal.jsx
@@ -106,6 +106,13 @@ class WorklogModal extends Component<Props, State> {
     }
   }
 
+  setDateAndTimeToNow = (e) => {
+    const newTime = moment();
+    const newDate = moment().format('MM/DD/YYYY');
+    this.setState({ startTime: newTime });
+    this.setState({ date: newDate });
+  }
+
   handleTimeChange = label => (value) => {
     this.setState({ [label]: value });
   }
@@ -158,6 +165,18 @@ class WorklogModal extends Component<Props, State> {
           <ModalFooter>
             <Flex row style={{ justifyContent: 'flex-end', width: '100%' }}>
               <ButtonGroup>
+                <Button appearance="primary" onClick={this.setDateAndTimeToNow}>
+                  Now
+                </Button>
+                <Button
+                  appearance="subtle"
+                  onClick={() => {
+                    setModalState('worklog', false);
+                    setUiState('editWorklogId', null);
+                  }}
+                  >
+                  Cancel
+                </Button>
                 <Button
                   appearance="primary"
                   disabled={saveInProcess}

--- a/app/containers/Modals/WorklogModal/WorklogModal.jsx
+++ b/app/containers/Modals/WorklogModal/WorklogModal.jsx
@@ -93,7 +93,12 @@ class WorklogModal extends Component<Props, State> {
           timeSpent: nextProps.worklog.timeSpent,
           startTime: moment(nextProps.worklog.started),
           comment: nextProps.worklog.comment,
-        })
+        });
+      } else {
+        setTimeout(() => {
+          this.setState({ timeSpent: '' });
+          this.setDateAndTimeToNow();
+        }, 50);
       }
       setTimeout(() => {
         if (this.timeInput) this.timeInput.focus();

--- a/app/containers/Modals/WorklogModal/WorklogModal.jsx
+++ b/app/containers/Modals/WorklogModal/WorklogModal.jsx
@@ -105,12 +105,6 @@ class WorklogModal extends Component<Props, State> {
       });
     }
   }
-  setDateAndTimeToNow = (e) => {
-    const newTime = moment();
-    const newDate = moment().format('MM/DD/YYYY');
-    this.setState({ startTime: newTime });
-    this.setState({ date: newDate });
-  }
 
   setDateAndTimeToNow = (e) => {
     const newTime = moment();

--- a/app/containers/Modals/WorklogModal/WorklogModal.jsx
+++ b/app/containers/Modals/WorklogModal/WorklogModal.jsx
@@ -169,15 +169,6 @@ class WorklogModal extends Component<Props, State> {
                   Now
                 </Button>
                 <Button
-                  appearance="subtle"
-                  onClick={() => {
-                    setModalState('worklog', false);
-                    setUiState('editWorklogId', null);
-                  }}
-                  >
-                  Cancel
-                </Button>
-                <Button
                   appearance="primary"
                   disabled={saveInProcess}
                   onClick={() => {


### PR DESCRIPTION
https://github.com/web-pal/chronos-timetracker/issues/52

#### What's this PR do?
Add a "Now" Button;
If you add a new manual worklog, the date and time is set to "now";
If you add a new manual worklog, the time spent is set to empty;
#### Where should the reviewer start?
#### How should this be manually tested?
- open worklog and push "Now";
- open a new manual worklog after a while;
#### Any background context you want to provide?
#### Screenshots (if appropriate)
