### PR TITLE
Attempt at fixing issue #20

### DIFF
--- a/app/containers/Modals/SettingsModal/SettingsModal.jsx
+++ b/app/containers/Modals/SettingsModal/SettingsModal.jsx
@@ -164,6 +164,13 @@ const SettingsModal: StatelessFunctionalComponent<Props> = ({
                 'updateChannel',
               ));
             }}
+            automaticUpdate={settings.updateAutomatically}
+            setAutomaticUpdate={(value) => {
+              dispatch(settingsActions.setLocalDesktopSetting(
+                value,
+                'updateAutomatically',
+              ));
+            }}
             updateCheckRunning={updateCheckRunning}
             updateAvailable={updateAvailable}
             updateFetching={updateFetching}

--- a/app/containers/Modals/SettingsModal/Update/UpdateSettings.jsx
+++ b/app/containers/Modals/SettingsModal/Update/UpdateSettings.jsx
@@ -47,16 +47,20 @@ type Props = {
   updateCheckRunning: boolean,
   updateAvailable: string,
   updateFetching: boolean,
+  automaticUpdate: boolean,
+  setAutomaticUpdate: (automaticUpdate: boolean) => void,
   setChannel: (channel: string) => void,
   onUpdateClick: () => void,
 };
 
 const UpdateSettings: StatelessFunctionalComponent<Props> = ({
   channel,
+  setAutomaticUpdate,
   setChannel,
   updateCheckRunning,
   updateAvailable,
   updateFetching,
+  automaticUpdate,
   onUpdateClick,
 } : Props): Node => (
   <SettingsSectionContent style={{ width: '100%' }}>
@@ -120,6 +124,20 @@ const UpdateSettings: StatelessFunctionalComponent<Props> = ({
             </Button>
           }
         </ButtonGroup>
+        <Checkbox
+            isChecked={automaticUpdate === true}
+            value={automaticUpdate}
+            onChange={(ev) => {
+              const { value } = ev.target;
+              if (value === 'false') {
+                setAutomaticUpdate(true);
+              } else {
+                setAutomaticUpdate(false);
+              }
+            }}
+            label="Download and update automatically"
+            name="allowAutomaticUpdate"
+        />
       </Flex>
       <Flex column>
         <H100 style={{ padding: '12px 0 6px 0' }}>

--- a/app/sagas/initializeApp.js
+++ b/app/sagas/initializeApp.js
@@ -133,6 +133,7 @@ export function* initialConfigureApp({
       screenshotPreviewTime: 15,
       trayShowTimer: true,
       updateChannel: 'stable',
+      updateAutomatically: false,
     };
     yield call(
       setToStorage,

--- a/app/sagas/settings.js
+++ b/app/sagas/settings.js
@@ -28,6 +28,7 @@ import {
   throwError,
 } from './ui';
 import {
+  getFromStorage,
   setToStorage,
 } from './storage';
 
@@ -69,6 +70,26 @@ export function* onChangeLocalDesktopSettings({
     if (settingName === 'trayShowTimer' && !value) {
       remote.getGlobal('tray').setTitle('');
     }
+
+    if (settingName === 'updateAutomatically') {
+      yield call(
+        infoLog,
+        `switched updateAutomatically to ${value}`,
+      );
+
+      let settings = yield call(getFromStorage, 'localDesktopSettings');
+      settings.updateAutomatically = value;
+      yield call(
+        setToStorage,
+        'localDesktopSettings',
+        settings,
+      );
+
+      if (value) {
+        yield put(uiActions.checkForUpdatesRequest());
+      }
+    }
+
     if (settingName === 'updateChannel') {
       yield call(
         infoLog,

--- a/app/types/settings.js
+++ b/app/types/settings.js
@@ -38,6 +38,6 @@ export type SettingsGeneral = {
   showScreenshotPreview: boolean,
   trayShowTimer: boolean,
   updateChannel: string,
-
+  updateAutomatically: boolean,
   isEmptyWorklogForbid: boolean,
 };


### PR DESCRIPTION
#### What's this PR do?
This is an attempt to fix issue #20.

#### Where should the reviewer start?

In order to understand the changes, this flow could be helpful:

1. app/sagas/initializeApp.js
2. app/types/settings.js
3. app/containers/Modals/SettingsModal/Update/UpdateSettings.jsx
4. app/containers/Modals/SettingsModal/SettingsModal.jsx
5. app/sagas/settings.js
6. app/sagas/updater.js

#### How should this be manually tested?

In order to test this, I used an earlier version (v2.6.3) located from https://github.com/web-pal/chronos-timetracker/tags
Just replace the original files with the ones from this commit.
Finally, build the project and rub the "Chronos Setup 2.6.2.exe" file.

#### Any background context you want to provide?

In case the user selects the "Download and update automatically" checkbox, I used the "localDesktopSettings" from storage to store a boolean named "updateAutomatically".

Regarding the changelog in the confirmation modal, since the changelog in "meta.ev.releaseNotes" comes in an HTML string, I used regular expressions to parse the HTML into a normal string (with line breaks and everything).

#### Screenshots (if appropriate)

Once an update has been downloaded, if the user did not select to update automatically, this panel will appear with the new release changelog:

![changelog](https://user-images.githubusercontent.com/32868127/38323705-fcb83f36-3835-11e8-868e-1358ad8e1771.png)
