### PR TITLE
Fix typo in error message

### DIFF
--- a/app/renderer/api/index.js
+++ b/app/renderer/api/index.js
@@ -27,7 +27,7 @@ export function authSelfHosted(
     'Error: net::ERR_CONNECTION_RESET': 'Connection reset',
     'Error: net::ERR_CONNECTION_CLOSE': 'Connection close',
     'Error: net::ERR_NAME_NOT_RESOLVED': 'Page unavailable',
-    'Error: net::ERR_CONNECTION_TIMED_OUT': 'Nonnection timed out',
+    'Error: net::ERR_CONNECTION_TIMED_OUT': 'Connection timed out',
   }[error] || 'Unknown Error');
 
   const {


### PR DESCRIPTION
#### What's this PR do?

Fixes a typo in the error message

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/5839225/52989960-06488000-3430-11e9-902b-1e3265193b06.png)

#### How to reproduce

1. Enter wrong atlassian domain (in my case it was example.atlassia.net)
1. Try to log in